### PR TITLE
Fixes response when QAT returns QZ_BUF_ERROR

### DIFF
--- a/qatzip/errors.go
+++ b/qatzip/errors.go
@@ -45,6 +45,8 @@ var (
 	ErrInputBufferMode         = errors.New(QatErrHdr + "invalid input buffer mode")
 	ErrApplyPostInit           = errors.New(QatErrHdr + "cannot apply options after Reset() or I/O")
 	ErrApplyInvalidType        = errors.New(QatErrHdr + "option appied to incorrect type")
+	ErrMaxBufferGrowth         = errors.New(QatErrHdr + "cannot grow buffer large enough")
+	ErrParamMaxBufferLength    = errors.New(QatErrHdr + "invalid size for max buffer length")
 )
 
 func Error(errorCode int) (err error) {

--- a/qatzip/options.go
+++ b/qatzip/options.go
@@ -192,8 +192,14 @@ func OutputBufLengthOption(len int) Option {
 
 		switch z := a.(type) {
 		case *Writer:
+			if len > z.p.MaxBufferLength {
+				return ErrParamOutputBufLength
+			}
 			z.p.OutputBufLength = len
 		case *Reader:
+			if len > z.p.MaxBufferLength {
+				return ErrParamOutputBufLength
+			}
 			z.p.OutputBufLength = len
 		default:
 			return ErrApplyInvalidType
@@ -238,14 +244,13 @@ func BounceBufferLengthOption(len int) Option {
 	}
 }
 
-// If output buffer is too small (see QZ_BUF_ERROR) increase size of output buffer a factor of len and retry
+// If output buffer is too small (see QZ_BUF_ERROR) increase size of output buffer by len and retry
 // (Reader/Writer)
 func BufferGrowthOption(len int) Option {
 	return func(a applier) error {
 		if len < MinBufferLength {
 			return ErrParamBufferGrowth
 		}
-
 		switch z := a.(type) {
 		case *Reader:
 			z.p.BufferGrowth = len
@@ -397,6 +402,25 @@ func WaitCountThresholdOption(n int) Option {
 			z.p.WaitCountThreshold = n
 		case *QzBinding:
 			z.p.WaitCountThreshold = n
+		default:
+			return ErrApplyInvalidType
+		}
+
+		return nil
+	}
+}
+
+// Max size an output buffer can grow to in bytes
+func MaxBufferLengthOption(n int) Option {
+	return func(a applier) error {
+		if n < MinBufferLength {
+			return ErrParamMaxBufferLength
+		}
+		switch z := a.(type) {
+		case *Reader:
+			z.p.MaxBufferLength = n
+		case *Writer:
+			z.p.MaxBufferLength = n
 		default:
 			return ErrApplyInvalidType
 		}

--- a/qatzip/params.go
+++ b/qatzip/params.go
@@ -12,8 +12,9 @@ type InputBufferMode int
 const (
 	DefaultCompression        = 1
 	MinBufferLength           = 128 * 1024
+	DefaultMaxBufferLength    = 2 * 1024 * 1024 * 1024
 	DefaultBufferLength       = 128 * 1024 * 1024
-	DefaultBufferGrowth       = 1024 * 1024
+	DefaultBufferGrowth       = 128 * 1024 * 1024
 	DefaultBounceBufferLength = 512
 	MinBounceBufferLength     = 512
 )
@@ -125,6 +126,7 @@ const (
 // Configuration parameters for QATgo compression
 type params struct {
 	OutputBufLength    int             // Output buffer size for QAT (for Reader and Writer)
+	MaxBufferLength    int             // Maximum size for the output buffer to grow (Default 2GB)
 	InputBufLength     int             // Input buffer size for QAT (for Reader)
 	BufferGrowth       int             // How much to increase output buffer if required (Default 1MB)
 	Direction          Direction       // Configures hardware for compress, decompress, or both (Default: Both)
@@ -155,5 +157,6 @@ func defaultParams() (p params) {
 	p.InputBufLength = DefaultBufferLength
 	p.BufferGrowth = DefaultBufferGrowth
 	p.BounceBufferLength = DefaultBounceBufferLength
+	p.MaxBufferLength = DefaultMaxBufferLength
 	return
 }

--- a/qatzip/qatzip_internal.c
+++ b/qatzip/qatzip_internal.c
@@ -418,7 +418,7 @@ int qatzip_decompress(qatzip_state_t * state, unsigned char *in_buf, unsigned in
 		     stream->pending_in, stream->pending_out, status);
 	qatzip_debug_dump(QDL_DEBUG, state, stream->out, stream->out_sz);
 
-	if (status != QZ_OK) {
+	if (status != QZ_OK && status != QZ_BUF_ERROR) {
 		stream->out = NULL;
 		qatzip_debug(QDL_HIGH, state, QATHDR "error: decompressing input data (status: %d)\n", status);
 		return status;


### PR DESCRIPTION
Changes the Reader and the Writer to still use the processed results even after a buffer error from QAT.
Changes the normal resizing to be done after the output buffer draining, with the original resizing still being done if we get a buffer error with no processed results.
Adjusts the use of z.bufferGrowth to align with the BufferGrowthOption documentation. Before, it was being as a flat add, now it is used as a scaling of the previous size.

Upgrades qgzip dependency on qatgo 